### PR TITLE
Export buttons and alert fix

### DIFF
--- a/backend/app/clickHouse/routes.py
+++ b/backend/app/clickHouse/routes.py
@@ -1,4 +1,4 @@
-from flask import jsonify, request
+from flask import jsonify, request, Response
 from clickhouse_connect import get_client
 from dotenv import load_dotenv
 from queue import Queue
@@ -11,9 +11,11 @@ from ..rpc_client import TopicModelRpcClient  # Import the RPC client module
 import csv
 import io
 import pandas as pd
-from flask import Response
 from openpyxl import Workbook
 from io import BytesIO
+from reportlab.lib.pagesizes import letter, legal
+from reportlab.lib import colors
+from reportlab.pdfgen import canvas
 
 load_dotenv()
 
@@ -234,7 +236,8 @@ def export_data():
 
         #PDF Issue with default latin-1 encoding, maybe swap from FPDF
         #Maybe try with reportlab and canvas
-        #Keep copy as normal
+        elif export_format == 'json':
+            return formatted_rows
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/frontend/src/data.jsx
+++ b/frontend/src/data.jsx
@@ -26,6 +26,7 @@ function Data() {
   const [sentimentResults, setSentimentResults] = useState(null);
   const [loadingSentiment, setLoadingSentiment] = useState(false);
   const [searchData, setSearchData] = useState([]);
+  const [dataMessage, setDataMessage] = useState(false);
 
   // This ref controls whether the main results DataTable should fetch data
   const tableInitializedRef = useRef(false);
@@ -346,7 +347,11 @@ function Data() {
               });
               //3000 Alert
               if (apiData.recordsFiltered <= 3000) {
-                alert("Data contains 3000 rows or less.");
+                //alert("Data contains 3000 rows or less.");
+                setDataMessage(true);
+              }
+              else {
+                setDataMessage(false);
               }
             } else {
               console.error("API data is not in expected format:", apiData);
@@ -405,7 +410,20 @@ function Data() {
               window.open(`/api/export_data?format=excel&subreddit=${subreddit}&option=${selectedOption}&sentimentKeywords=${sentimentKeywords}&startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`, '_blank');
             }
           },
-          //Fix PDF, IN PROGRESS
+          {
+            text: 'CSV',
+            action: function () {
+              window.open(`/api/export_data?format=csv&subreddit=${subreddit}&option=${selectedOption}&sentimentKeywords=${sentimentKeywords}&startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`, '_blank');
+            }
+          },
+          //Replaced PDF with JSON
+          {
+            text: 'JSON',
+            action: function () {
+              window.open(`/api/export_data?format=json&subreddit=${subreddit}&option=${selectedOption}&sentimentKeywords=${sentimentKeywords}&startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`, '_blank');
+            }
+          },
+          //PDF AND COPY ONLY DO VISIBLE ROWS
           {
             extend: 'pdfHtml5',
             title: 'Table Export',
@@ -418,12 +436,6 @@ function Data() {
               columns: ':visible',
               orthogonal: 'export'
             },
-          },
-          {
-            text: 'CSV',
-            action: function () {
-              window.open(`/api/export_data?format=csv&subreddit=${subreddit}&option=${selectedOption}&sentimentKeywords=${sentimentKeywords}&startDate=${startDate.toISOString()}&endDate=${endDate.toISOString()}`, '_blank');
-            }
           },
           {
             extend: 'copy',
@@ -671,6 +683,7 @@ function Data() {
       {/* Main Results DataTable */}
       <div className="mt-5">
         <h2>Results</h2>
+        <h5>{dataMessage && <div style={{ color: 'red' }}>Data contains 3000 rows or less and may be insufficient.</div>}</h5>
         <div>
           <table id="click-table" className="display">
             <thead>


### PR DESCRIPTION
- Left PDF and copy to work only on the visible data entries, 10-100.
- Added a json button that is savable. 
- Changed 3000 or less data alert to be text rather than alert due to datatables reloading making it appear multiple times.