### PR TITLE
Search Suggestion and Fixes

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,7 +17,7 @@ class SearchHistory(db.Model):
     startDate = db.Column(db.Date, nullable=False)
     endDate = db.Column(db.Date, nullable=False)
     option = db.Column(db.String(), nullable=False)
-    created_utc = db.Column(db.DateTime, nullable=False, default=datetime.now(timezone.utc))
+    created_utc = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
 # Results Model
 class ResultData(db.Model):
@@ -28,7 +28,7 @@ class ResultData(db.Model):
     subreddit = db.Column(db.String(), nullable=False)
     startDate = db.Column(db.Date, nullable=False)
     endDate = db.Column(db.Date, nullable=False)
-    created_utc = db.Column(db.DateTime, nullable=False, default=datetime.now(timezone.utc))
+    created_utc = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     # Topic Relationship
     groups = db.relationship(
         "TopicData",

--- a/frontend/src/SearchSuggestions.jsx
+++ b/frontend/src/SearchSuggestions.jsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useRef, useState } from "react";
+
+const SearchSuggestions = ({ subreddit, setSubreddit, getSubredditIcon, isTyping, setIsTyping }) => {
+    const [suggestions, setSuggestions] = useState([]);
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [suggestionLoading, setSuggestionLoading] = useState(false);
+    const suggestionCounter = useRef(0);
+
+    const fetchSubreddits = async (query) => {
+        try {
+            const response = await fetch(`/api/search_list?subreddit=${query}`);
+            const data = await response.json();
+            return data || [];
+        } catch (error) {
+            console.error("Error fetching subreddits:", error);
+            return [];
+        }
+    };
+
+    useEffect(() => {
+        if (subreddit.length > 0 && isTyping) {
+            const timer = setTimeout(async () => {
+                const suggestionCounterId = ++suggestionCounter.current;
+                setSuggestionLoading(true);
+                const subreddit_list = await fetchSubreddits(subreddit);
+
+                if (suggestionCounterId === suggestionCounter.current) {
+                    setSuggestions(subreddit_list);
+                    setShowSuggestions(subreddit_list.length > 0);
+                    setSuggestionLoading(false);
+                }
+            }, 150);
+
+            return () => clearTimeout(timer);
+        } else {
+            setSuggestions([]);
+            setShowSuggestions(false);
+        }
+    }, [subreddit, isTyping]);
+
+    const handleSuggestionClick = (suggestion) => {
+        setSubreddit(suggestion);
+        getSubredditIcon(suggestion);
+        setSuggestions([]);
+        setShowSuggestions(false);
+        setIsTyping(false);
+    };
+
+    return (
+        <>
+            {suggestionLoading && (
+                <div className="mt-2 text-warning">Loading...</div>
+            )}
+
+            {showSuggestions && suggestions.length > 0 && (
+                <ul
+                    className="list-group mt-2"
+                    style={{ maxHeight: "200px", overflowY: "auto" }}
+                >
+                    {suggestions.map((suggestion, index) => (
+                        <li
+                            key={index}
+                            className="list-group-item"
+                            style={{ cursor: "pointer" }}
+                            onClick={() => handleSuggestionClick(suggestion)}
+                        >
+                            r/{suggestion}
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {!suggestions.length && !suggestionLoading && isTyping && (
+                <div className="text-danger mt-2">No subreddits match the search.</div>
+            )}
+        </>
+    );
+};
+
+export default SearchSuggestions;

--- a/frontend/src/TopicTable.jsx
+++ b/frontend/src/TopicTable.jsx
@@ -13,8 +13,8 @@ const TopicTable = ({ group, showPosts }) => {
   }, [group]);
 
   return (
-    <div>
-      <table ref={tableRef} className="display">
+    <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+      <table ref={tableRef} className="display_cluster">
         <thead>
           <tr>
             <th>Topic Number</th>

--- a/frontend/src/data.jsx
+++ b/frontend/src/data.jsx
@@ -14,6 +14,7 @@ import 'datatables.net-buttons/js/buttons.html5.min';
 import 'datatables.net-buttons/js/buttons.print.min';
 import TopicTablesContainer from './TopicTablesContainer';
 import handleNotify from './toast';
+import SearchSuggestions from './SearchSuggestions';
 import { ToastContainer } from 'react-toastify';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, BarElement } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
@@ -342,7 +343,7 @@ function Data() {
                 return labels.join(", ");
               }
             },
-            { data: "created_utc", title: "Created Date" },
+            { data: "created_utc", title: "Created UTC" },
             {
               data: null,
               title: "Actions",
@@ -415,7 +416,7 @@ function Data() {
             return labels.join(", ");
           }
         },
-        { data: "created_utc", title: "Created Date" },
+        { data: "created_utc", title: "Created UTC" },
         {
           data: null,
           title: "Actions",
@@ -559,7 +560,12 @@ function Data() {
         columns: [
           { data: "subreddit", title: "Subreddit", width: '10%' },
           { data: "title", title: "Title", width: '20%' },
-          { data: "selftext", title: "Body", width: '50%' },
+          {
+            data: "selftext",
+            title: "Body",
+            width: '50%',
+            className: 'wrap-text'
+          },
           { data: "created_utc", title: "Created UTC", width: '150px' },
           {
             data: "id",
@@ -701,7 +707,11 @@ function Data() {
               paging: true,
               searching: true,
               responsive: true,
-              autoWidth: false
+              autoWidth: false,
+              scrollY: '600px',
+              scrollCollapse: true,
+              scroller: true,
+              fixedHeader: true,
               // Add any additional DataTable options as needed.
             });
           }
@@ -883,6 +893,12 @@ function Data() {
     }
   };
 
+  const [isTyping, setIsTyping] = useState(false);
+  const handleChange = (e) => {
+    setIsTyping(true);
+    setSubreddit(e.target.value);
+  }
+
   const baseColors = [
     '255, 99, 132',
     '255, 159, 64',
@@ -981,15 +997,24 @@ function Data() {
                   type="text"
                   className="form-control"
                   value={subreddit}
-                  onChange={(e) => setSubreddit(e.target.value)}
+                  onChange={handleChange}
                   placeholder="Enter subreddit (e.g. news)"
                 />
               </div>
+
               {!subreddit.trim() && (
                 <div className="text-danger mt-2">
                   Please enter a subreddit.
                 </div>
               )}
+
+              <SearchSuggestions
+                subreddit={subreddit}
+                setSubreddit={setSubreddit}
+                getSubredditIcon={getSubredditIcon}
+                isTyping={isTyping}
+                setIsTyping={setIsTyping}
+              />
             </div>
 
             <div className="mt-4">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,3 +52,17 @@ div.dt-length>select#dt-length-2 {
     max-width: 70%;
   }
 }
+
+.wrap-text {
+  word-break: break-word !important;
+  white-space: normal !important;
+  overflow-wrap: break-word;
+  max-width: 100%;
+}
+
+.display_cluster th {
+  position: sticky;
+  top: 0;
+  background-color: #212529;
+  z-index: 1;
+}

--- a/frontend/src/results.jsx
+++ b/frontend/src/results.jsx
@@ -83,8 +83,8 @@ const Results = () => {
                     {groupedResults.map((group, rowIndex) => (
                         <div className="row my-4 d-flex align-items-stretch" key={rowIndex}>
                             {group.map((resultCard, columnIndex) => (
-                                <div className="col-md-4" key={columnIndex}>
-                                    <div className="card h-100 p-3 shadow-lg">
+                                <div className="col-md-4 d-flex" key={columnIndex}>
+                                    <div className="card h-100 d-flex flex-column p-3 shadow-lg">
                                         <h5 className="card-title">Experiment {resultCard.id}</h5>
                                         <p className="card-text"><span className="text-decoration-underline">User:</span> {resultCard.email}</p>
 
@@ -94,7 +94,7 @@ const Results = () => {
                                             <span className="text-decoration-underline">Date Range:</span> {new Date(resultCard.startDate).toLocaleDateString()} - {new Date(resultCard.endDate).toLocaleDateString()}
                                         </p>
                                         <p className="card-text mb-0">
-                                            <span className="text-decoration-underline">Created:</span>{" "}
+                                            <span className="text-decoration-underline">Created UTC:</span>{" "}
                                             {new Date(resultCard.created_utc).toLocaleString()}
                                         </p>
 
@@ -105,8 +105,7 @@ const Results = () => {
 
                                         <button
                                             type="button"
-                                            margin-top="auto"
-                                            className="btn btn-primary mt-2"
+                                            className="btn btn-primary mt-2 mt-auto"
                                             data-bs-toggle="modal"
                                             data-bs-target="#showTopics"
                                             onClick={() => handleShowTopicInfo(resultCard.id)}
@@ -178,7 +177,6 @@ const Results = () => {
                                         {email === resultCard.email && (
                                             <button
                                                 className="btn btn-danger mt-3"
-                                                margin-top="auto"
                                                 onClick={() => handleRemoveResult(resultCard.id)}
                                             >
                                                 Remove Result


### PR DESCRIPTION
- Fixed text wrapping in main datatables, some of the body text would contain words that went beyond the width of the datatables and extended it.
- Fixed button placements, result page buttons should now be placed towards the bottom.
- Testing, made topic cluster table scrollable by group, open to changes.
- Issue with case sensitive subreddit search, using ILIKE made the query very slow.
- Integrated search suggestions list with ILIKE so it does not affect the main query and allows users to select options that will have the proper capitalization.
- Issues with content moderation adding too many topics, i.e. for survivor i got 240 total topics with 38 of them being about moderation with many of them being single post topics